### PR TITLE
Don't process dot files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: dart
 
-dart: dev
+dart: stable
 
 env:
   global:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.1
+
+- Don't process dot files.
+
 ## 0.6.0
 
 - Upgrade to v1 of `builder` and `build_runner`.
@@ -42,4 +46,4 @@
 - First public version, inspired by JavaScript-based
   [github.com/chalin/code-excerpter](https://github.com/chalin/code-excerpter),
   which was derived from tooling used under angular.io.
-  
+

--- a/build.yaml
+++ b/build.yaml
@@ -13,6 +13,7 @@ builders:
           - test/**
           - web/**
         exclude:
+          - '**/.*'
           - '**/.*/**'
           - '**/.DS_Store'
           - '**/build/**'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: code_excerpter
-version: 0.6.0
+version: 0.6.1
 description: A line-based utility for extracting code regions.
 
 author: Patrice Chalin <pchalin@gmail.com>


### PR DESCRIPTION
Fixes https://github.com/dart-lang/site-www/issues/1821, which was motivated by a breakage in the build (see https://github.com/dart-lang/site-www/issues/1818) due to a temporary Vim file (named `package:crypto/src/.sha512.dart.swp`) being included in one of the imported packages.