### PR TITLE
YAML excerpt values now have a mandatory left border character

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,14 @@ env:
     - TASK="dartanalyzer --fatal-warnings $LIBS analysis_options.yaml"
     - TASK="pub run test"
     - TASK="tool/builder_test.sh"
-    - TASK="dartfmt -n $LIBS"
+    - TASK="dartfmt --set-exit-if-changed -n $LIBS"
 
 dart_task: []
 
 jobs:
   exclude:
     - dart: dev
-      env:  TASK="dartfmt -n $LIBS"
+      env:  TASK="dartfmt --set-exit-if-changed -n $LIBS"
 
 script: [pub get, $TASK]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.0.0
+
+- When YAML excerpt files are generated, the excerpt values
+  are now multiline strings with a left border character as
+  the first character of each line. The value of the special
+  map key '#border' is the border character. (The code-excerpt
+  updater trims of this border character when present.)
+
 ## 0.6.2
 
 - Internal changes (ran dartfmt --fix).

--- a/build_expected/test/builder_input/example.dart.excerpt.yaml
+++ b/build_expected/test/builder_input/example.dart.excerpt.yaml
@@ -1,27 +1,28 @@
+'#border': '|'
 'imports': |+
-  import 'dart:async';
+  |import 'dart:async';
 'main': |+
-  void main() async {
-    print('Compute π using the Monte Carlo method.');
-    await for (var estimate in computePi().take(500)) {
-      print('π ≅ $estimate');
-    }
-  }
+  |void main() async {
+  |  print('Compute π using the Monte Carlo method.');
+  |  await for (var estimate in computePi().take(500)) {
+  |    print('π ≅ $estimate');
+  |  }
+  |}
 'main-stub': |+
-  void main() async {
-    ···
-  }
+  |void main() async {
+  |  ···
+  |}
 '': |+
-  import 'dart:async';
-  
-  void main() async {
-    print('Compute π using the Monte Carlo method.');
-    await for (var estimate in computePi().take(500)) {
-      print('π ≅ $estimate');
-    }
-  }
-  
-  /// Generates a stream of increasingly accurate estimates of π.
-  Stream<double> computePi({int batch = 100000}) async* {
-    // ...
-  }
+  |import 'dart:async';
+  |
+  |void main() async {
+  |  print('Compute π using the Monte Carlo method.');
+  |  await for (var estimate in computePi().take(500)) {
+  |    print('π ≅ $estimate');
+  |  }
+  |}
+  |
+  |/// Generates a stream of increasingly accurate estimates of π.
+  |Stream<double> computePi({int batch = 100000}) async* {
+  |  // ...
+  |}

--- a/build_expected/test/builder_input/example.html.excerpt.yaml
+++ b/build_expected/test/builder_input/example.html.excerpt.yaml
@@ -1,28 +1,29 @@
+'#border': '|'
 'head': |+
-  <head>
-      <meta charset="UTF-8">
-      <title>Title</title>
-  </head>
+  |<head>
+  |    <meta charset="UTF-8">
+  |    <title>Title</title>
+  |</head>
 'head+body': |+
-  <head>
-      <meta charset="UTF-8">
-      <title>Title</title>
-  </head>
-  <body>
-  
-  </body>
+  |<head>
+  |    <meta charset="UTF-8">
+  |    <title>Title</title>
+  |</head>
+  |<body>
+  |
+  |</body>
 'body': |+
-  <body>
-  
-  </body>
+  |<body>
+  |
+  |</body>
 '': |+
-  <!DOCTYPE html>
-  <html lang="en">
-  <head>
-      <meta charset="UTF-8">
-      <title>Title</title>
-  </head>
-  <body>
-  
-  </body>
-  </html>
+  |<!DOCTYPE html>
+  |<html lang="en">
+  |<head>
+  |    <meta charset="UTF-8">
+  |    <title>Title</title>
+  |</head>
+  |<body>
+  |
+  |</body>
+  |</html>

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -5,6 +5,8 @@ import 'package:build/build.dart';
 import 'package:code_excerpter/src/util/line.dart';
 import 'package:code_excerpter/src/excerpter.dart';
 
+const excerptLineLeftBorderChar = '|';
+
 Builder builder(BuilderOptions options) => CodeExcerptBuilder(options);
 
 class CodeExcerptBuilder implements Builder {
@@ -38,8 +40,12 @@ class CodeExcerptBuilder implements Builder {
       };
 
   String _toYaml(Map<String, List<String>> excerpts) {
+    if (excerpts.isEmpty) return '';
+
+    const yamlExcerptLeftBorderCharKey = '#border';
     final StringBuffer s = StringBuffer();
 
+    s.writeln("'$yamlExcerptLeftBorderCharKey': '$excerptLineLeftBorderChar'");
     excerpts.forEach((name, lines) {
       s.writeln(_yamlEntry(name, lines));
     });
@@ -48,7 +54,8 @@ class CodeExcerptBuilder implements Builder {
 
   String _yamlEntry(String regionName, List<String> lines) {
     final codeAsYamlStringValue = lines
-        .map((line) => '  $line') // indent by 2 spaces for YAML
+        // YAML multiline string: indent by 2 spaces.
+        .map((line) => '  $excerptLineLeftBorderChar$line')
         .join(eol);
     return "'$regionName': |+\n$codeAsYamlStringValue";
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: code_excerpter
-version: 0.6.2
+version: 1.0.0
 description: A line-based utility for extracting code regions.
 
 author: Patrice Chalin <pchalin@gmail.com>
@@ -9,11 +9,11 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  build: ^1.0.2
+  build: ^1.2.2
   logging: ^0.11.3+1
   path: ^1.6.0
   yaml: ^2.1.0
 
 dev_dependencies:
-  build_runner: ^1.1.2
+  build_runner: ^1.8.0
   test: ^1.0.0


### PR DESCRIPTION
... when generated using the builder. This should contribute to #17.